### PR TITLE
Add "assert-callback" module as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     }
   },
   "devDependencies": {
+    "assert-callback": "^0.1.0",
     "babel-plugin-istanbul": "^4.1.5",
     "babel-preset-latest": "^6.24.1",
     "babel-register": "^6.26.0",


### PR DESCRIPTION
`npm test` command fails due to missing `assert-callback` module. `assert-callback` added as a development dependency